### PR TITLE
fix TypeError for python 3.4

### DIFF
--- a/usnparser/usn.py
+++ b/usnparser/usn.py
@@ -183,7 +183,7 @@ def main():
             i.seek(findFirstRecord(i))
 
             if args.csv:
-                o.write(u'timestamp,filename,fileattr,reason\n')
+                o.write(u'timestamp,filename,fileattr,reason\n'.encode('utf-8', errors='backslashreplace'))
                 while True:
                     nextRecord = findNextRecord(i, journalSize)
                     recordLength = struct.unpack_from('<I', i.read(4))[0]


### PR DESCRIPTION
When used with python 3.4, the the tool immediately exits and raises the following error:

```
Traceback (most recent call last):
  File "/home/yay/.local/bin/usn.py", line 263, in <module>
    main()
  File "/home/yay/.local/bin/usn.py", line 186, in main
    o.write(u'timestamp,filename,fileattr,reason\n')
TypeError: 'str' does not support the buffer interface
```
The PR satisfies the python3 requirement for which the bytes given in input to the `write()`  call must be properly encoded.
