### PR TITLE
Updated for Python 3, addl tweaks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,16 +22,22 @@ Command-Line Options
 
 ::
 
+    usage: usn.py [-h] [-b] [-c] -f FILE -o OUTFILE [-s SYSTEM] [-t] [-V] [-v]
+
+    usnparser v5.0.0
+
     optional arguments:
       -h, --help            show this help message and exit
-      -b, --body            Return USN records in comma-separated format
+      -b, --body            Return USN records in body file format
       -c, --csv             Return USN records in comma-separated format
       -f FILE, --file FILE  Parse the given USN journal file
-      -q, --quick           Parse a large journal file quickly
+      -o OUTFILE, --outfile OUTFILE
+                            Output records to given file
       -s SYSTEM, --system SYSTEM
-                            System name (use with -t)
-      -t, --tln             TLN output (use with -s)
-      -v, --verbose         Return all USN properties for each record (JSON)
+                            System hostname (use with -t)
+      -t, --tln             TLN ou2tput (use with -s)
+      -V, --verbose         Return all USN properties for each record (JSON)
+      -v, --version         show program's version number and exit
 
 **--csv**
 
@@ -70,7 +76,7 @@ Using the --tln / -t command-line flag, the script will output in TLN body forma
 
     dev@computer:~$ python usn.py -f usnjournal --tln
 
-    1491238176|USN|||schedule log.xml:DATA_EXTEND DATA_TRUNCATION CLOSE
+    1491238176|USN|||schedule log.xml;DATA_EXTEND DATA_TRUNCATION CLOSE
 
 
 Add the --system / -s flag to specify a system name with TLN output:
@@ -79,7 +85,7 @@ Add the --system / -s flag to specify a system name with TLN output:
 
     dev@computer:~$ python usn.py -f usnjournal --tln --system ThisIsASystemName
 
-    1491238176|USN|ThisIsASystemName||schedule log.xml:DATA_EXTEND DATA_TRUNCATION CLOSE
+    1491238176|USN|ThisIsASystemName||schedule log.xml;DATA_EXTEND DATA_TRUNCATION CLOSE
 
 **--verbose**
 
@@ -91,25 +97,25 @@ Return all USN members for each record with the --verbose / -v flag. The results
     dev@computer:~$cat /tmp/usn.txt
 
     {
-        "majorVersion": 2,
-        "minorVersion": 0,
-        "fileReferenceNumber": 281474976744952,
-        "parentFileReferenceNumber": 844424930165539,
-        "usn": 47265504,
-        "timestamp": 1467312724,
-        "reason": "SECURITY_CHANGE",
+        "filename": "62e4f811156dd101d900000084088c08.Specialize.xml",
+        "humanTimestamp": "2016-02-22 02:02:23.371990",
+        "timestamp": "01d16d1511f8e462",
+        "epochTimestamp": 1456106543371,
+        "usn": 8389448,
+        "fileReferenceNumber": 844424930229305,
+        "parentFileReferenceNumber": 281474976725213,
+        "reason": "DATA_EXTEND FILE_CREATE",
+        "fileAttributes": "ARCHIVE",
+        "mftSeqNumber": 3,
+        "mftEntryNumber": 97337,
+        "pMftSeqNumber": 1,
+        "pMftEntryNumber": 14557,
+        "filenameLength": 94,
+        "filenameOffset": 60,
         "sourceInfo": 0,
         "securityId": 0,
-        "fileAttributes": "HIDDEN SYSTEM ARCHIVE",
-        "filenameLength": 22,
-        "filenameOffset": 60,
-        "filename": "493fde4.rbf",
-        "humanTimestamp": "2016-06-30 18:52:04.456762",
-        "epochTimestamp": 1467312724,
-        "mftSeqNumber": 1,
-        "mftEntryNumber": 34296,
-        "pMftSeqNumber": 3,
-        "pMftEntryNumber": 33571
+        "majorVersion": 2,
+        "minorVersion": 0
     }
 
 Installation
@@ -118,11 +124,11 @@ Using setup.py:
 
 ::
     
-    python setup.py install
+    python3 setup.py install
     
 Using pip:
 
 ::
     
-    pip install usnparser
+    python3 -m pip install usnparser
 

--- a/setup.py
+++ b/setup.py
@@ -9,14 +9,15 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='usnparser',
-    version='4.1.6',
-    description='A Python script to parse the NTFS USN journal',
+    version='5.0.0',
+    description='A Python 3 script to parse the NTFS USN journal',
     long_description=long_description,
-    url='https://github.com/PoorBillionaire/USN-Journal-Parser',
-    author='Adam Witt',
-    author_email='accidentalassist@gmail.com',
+    url='https://github.com/digitalsleuth/USN-Journal-Parser',
+    author='Adam Witt, Corey Forman',
+    author_email='corey@digitalsleuth.ca',
     license='Apache Software License',
     classifiers=[
+        'Programming Language :: Python :: 3',
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Information Technology',
         'Topic :: Security',

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
-unzip tests/usnjrnl.zip
-usn.py -h
-usn.py -f usnjrnl.bin -o /tmp/usn.txt
+unzip usnjrnl.zip
+../usnparser/usn.py -h
+../usnparser/usn.py -f usnjrnl.bin -o /tmp/usn.txt
 cat /tmp/usn.txt
-usn.py --csv -f usnjrnl.bin -o /tmp/usn.txt
+../usnparser/usn.py --csv -f usnjrnl.bin -o /tmp/usn.txt
 cat /tmp/usn.txt
-usn.py --verbose -f usnjrnl.bin -o /tmp/usn.txt
+../usnparser/usn.py --verbose -f usnjrnl.bin -o /tmp/usn.txt
 cat /tmp/usn.txt
-usn.py --tln -f usnjrnl.bin -o /tmp/usn.txt
+../usnparser/usn.py --tln -f usnjrnl.bin -o /tmp/usn.txt
 cat /tmp/usn.txt
-usn.py --tln --system ThisIsASystemName -f usnjrnl.bin -o /tmp/usn.txt
+../usnparser/usn.py --tln --system ThisIsASystemName -f usnjrnl.bin -o /tmp/usn.txt
 cat /tmp/usn.txt
-usn.py --body -f usnjrnl.bin -o /tmp/usn.txt
+../usnparser/usn.py --body -f usnjrnl.bin -o /tmp/usn.txt
 cat /tmp/usn.txt
-usn.py --body -f usnjrnl.bin -o /tmp/usn.txt
+#../usnparser/usn.py --body -f usnjrnl.bin -o /tmp/usn.txt
 mactime -b /tmp/usn.txt

--- a/usnparser/usn.py
+++ b/usnparser/usn.py
@@ -1,5 +1,5 @@
-#!/usr/bin/python
-#
+#!/usr/bin/python3
+"""
 # Copyright 2017 Adam Witt
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
@@ -14,10 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Contact: <accidentalassist@gmail.com>
+# Original Author - Contact: <accidentalassist@gmail.com>
+# Updated for Python 3 by Corey Forman <github.com/digitalsleuth>
+"""
+__author__ = 'Adam Witt / Corey Forman'
+__version__ = '5.0.0'
+__date__ = '15 July 2022'
+__description__ = 'Python 3 script to parse the NTFS USN Journal'
 
-
-from __future__ import print_function
 
 import os
 import sys
@@ -25,90 +29,121 @@ import json
 import struct
 import collections
 from argparse import ArgumentParser
-from datetime import datetime,timedelta
+from datetime import datetime
 
 
 reasons = collections.OrderedDict()
-reasons[0x1] = u'DATA_OVERWRITE'
-reasons[0x2] = u'DATA_EXTEND'
-reasons[0x4] = u'DATA_TRUNCATION'
-reasons[0x10] = u'NAMED_DATA_OVERWRITE'
-reasons[0x20] = u'NAMED_DATA_EXTEND'
-reasons[0x40] = u'NAMED_DATA_TRUNCATION'
-reasons[0x100] = u'FILE_CREATE'
-reasons[0x200] = u'FILE_DELETE'
-reasons[0x400] = u'EA_CHANGE'
-reasons[0x800] = u'SECURITY_CHANGE'
-reasons[0x1000] = u'RENAME_OLD_NAME'
-reasons[0x2000] = u'RENAME_NEW_NAME'
-reasons[0x4000] = u'INDEXABLE_CHANGE'
-reasons[0x8000] = u'BASIC_INFO_CHANGE'
-reasons[0x10000] = u'HARD_LINK_CHANGE'
-reasons[0x20000] = u'COMPRESSION_CHANGE'
-reasons[0x40000] = u'ENCRYPTION_CHANGE'
-reasons[0x80000] = u'OBJECT_ID_CHANGE'
-reasons[0x100000] = u'REPARSE_POINT_CHANGE'
-reasons[0x200000] = u'STREAM_CHANGE'
-reasons[0x80000000] = u'CLOSE'
+reasons[0x1] = 'DATA_OVERWRITE'
+reasons[0x2] = 'DATA_EXTEND'
+reasons[0x4] = 'DATA_TRUNCATION'
+reasons[0x10] = 'NAMED_DATA_OVERWRITE'
+reasons[0x20] = 'NAMED_DATA_EXTEND'
+reasons[0x40] = 'NAMED_DATA_TRUNCATION'
+reasons[0x100] = 'FILE_CREATE'
+reasons[0x200] = 'FILE_DELETE'
+reasons[0x400] = 'EA_CHANGE'
+reasons[0x800] = 'SECURITY_CHANGE'
+reasons[0x1000] = 'RENAME_OLD_NAME'
+reasons[0x2000] = 'RENAME_NEW_NAME'
+reasons[0x4000] = 'INDEXABLE_CHANGE'
+reasons[0x8000] = 'BASIC_INFO_CHANGE'
+reasons[0x10000] = 'HARD_LINK_CHANGE'
+reasons[0x20000] = 'COMPRESSION_CHANGE'
+reasons[0x40000] = 'ENCRYPTION_CHANGE'
+reasons[0x80000] = 'OBJECT_ID_CHANGE'
+reasons[0x100000] = 'REPARSE_POINT_CHANGE'
+reasons[0x200000] = 'STREAM_CHANGE'
+reasons[0x800000] = 'INTEGRITY_CHANGE'
+reasons[0x00400000] = 'TRANSACTED_CHANGE'
+reasons[0x80000000] = 'CLOSE'
 
 
 attributes = collections.OrderedDict()
-attributes[0x1] = u'READONLY'
-attributes[0x2] = u'HIDDEN'
-attributes[0x4] = u'SYSTEM'
-attributes[0x10] = u'DIRECTORY'
-attributes[0x20] = u'ARCHIVE'
-attributes[0x40] = u'DEVICE'
-attributes[0x80] = u'NORMAL'
-attributes[0x100] = u'TEMPORARY'
-attributes[0x200] = u'SPARSE_FILE'
-attributes[0x400] = u'REPARSE_POINT'
-attributes[0x800] = u'COMPRESSED'
-attributes[0x1000] = u'OFFLINE'
-attributes[0x2000] = u'NOT_CONTENT_INDEXED'
-attributes[0x4000] = u'ENCRYPTED'
-attributes[0x8000] = u'INTEGRITY_STREAM'
-attributes[0x10000] = u'VIRTUAL'
-attributes[0x20000] = u'NO_SCRUB_DATA'
+attributes[0x1] = 'READONLY'
+attributes[0x2] = 'HIDDEN'
+attributes[0x4] = 'SYSTEM'
+attributes[0x10] = 'DIRECTORY'
+attributes[0x20] = 'ARCHIVE'
+attributes[0x40] = 'DEVICE'
+attributes[0x80] = 'NORMAL'
+attributes[0x100] = 'TEMPORARY'
+attributes[0x200] = 'SPARSE_FILE'
+attributes[0x400] = 'REPARSE_POINT'
+attributes[0x800] = 'COMPRESSED'
+attributes[0x1000] = 'OFFLINE'
+attributes[0x2000] = 'NOT_CONTENT_INDEXED'
+attributes[0x4000] = 'ENCRYPTED'
+attributes[0x8000] = 'INTEGRITY_STREAM'
+attributes[0x10000] = 'VIRTUAL'
+attributes[0x20000] = 'NO_SCRUB_DATA'
 
 
 sourceInfo = collections.OrderedDict()
-sourceInfo[0x1] = u'DATA_MANAGEMENT'
-sourceInfo[0x2] = u'AUXILIARY_DATA'
-sourceInfo[0x4] = u'REPLICATION_MANAGEMENT'
+sourceInfo[0x1] = 'DATA_MANAGEMENT'
+sourceInfo[0x2] = 'AUXILIARY_DATA'
+sourceInfo[0x4] = 'REPLICATION_MANAGEMENT'
+sourceInfo[0x8] = 'CLIENT_REPLICATION_MANAGEMENT'
 
 
 def parseUsn(infile, usn):
     recordProperties = [
-        u'majorVersion',
-        u'minorVersion',
-        u'fileReferenceNumber',
-        u'parentFileReferenceNumber',
-        u'usn',
-        u'timestamp',
-        u'reason',
-        u'sourceInfo',
-        u'securityId',
-        u'fileAttributes',
-        u'filenameLength',
-        u'filenameOffset'
+        'majorVersion',
+        'minorVersion',
+        'fileReferenceNumber',
+        'parentFileReferenceNumber',
+        'usn',
+        'timestamp',
+        'reason',
+        'sourceInfo',
+        'securityId',
+        'fileAttributes',
+        'filenameLength',
+        'filenameOffset'
     ]
     recordDict = dict(zip(recordProperties, usn))
-    recordDict[u'filename'] = filenameHandler(infile, recordDict)
-    recordDict[u'reason'] = convertAttributes(reasons, recordDict[u'reason'])
-    recordDict[u'fileAttributes'] = convertAttributes(attributes, recordDict[u'fileAttributes'])
-    recordDict[u'humanTimestamp'] = filetimeToHumanReadable(recordDict[u'timestamp'])
-    recordDict[u'epochTimestamp'] = filetimeToEpoch(recordDict[u'timestamp'])
-    recordDict[u'timestamp'] = filetimeToEpoch(recordDict[u'timestamp'])
-    recordDict[u'mftSeqNumber'], recordDict[u'mftEntryNumber'] = convertFileReference(recordDict[u'fileReferenceNumber'])
-    recordDict[u'pMftSeqNumber'], recordDict[u'pMftEntryNumber'] = convertFileReference(recordDict[u'parentFileReferenceNumber'])
+    recordDict['filename'] = filenameHandler(infile, recordDict)
+    recordDict['reason'] = convertAttributes(reasons, recordDict['reason'])
+    recordDict['fileAttributes'] = convertAttributes(
+        attributes, recordDict['fileAttributes'])
+    recordDict['humanTimestamp'] = filetimeToHumanReadable(
+        recordDict['timestamp'])
+    recordDict['epochTimestamp'] = filetimeToEpoch(recordDict['timestamp'])
+    recordDict['timestamp'] = f"{recordDict['timestamp']:016x}"
+    recordDict['mftSeqNumber'], recordDict['mftEntryNumber'] = convertFileReference(
+        recordDict['fileReferenceNumber'])
+    recordDict['pMftSeqNumber'], recordDict['pMftEntryNumber'] = convertFileReference(
+        recordDict['parentFileReferenceNumber'])
+    reorder = [
+        'filename',
+        'humanTimestamp',
+        'timestamp',
+        'epochTimestamp',
+        'usn',
+        'fileReferenceNumber',
+        'parentFileReferenceNumber',
+        'reason',
+        'fileAttributes',
+        'mftSeqNumber',
+        'mftEntryNumber',
+        'pMftSeqNumber',
+        'pMftEntryNumber',
+        'filenameLength',
+        'filenameOffset',
+        'sourceInfo',
+        'securityId',
+        'majorVersion',
+        'minorVersion'
+    ]
+    recordDict = {key: recordDict[key] for key in reorder}
     return recordDict
 
 
 def findFirstRecord(infile):
-    # Returns a pointer to the first USN record found
-    # Modified version of Dave Lassalle's 'parseusn.py'
-    # https://github.com/sans-dfir/sift-files/blob/master/scripts/parseusn.py
+    """
+    Returns a pointer to the first USN record found
+    Modified version of Dave Lassalle's 'parseusn.py'
+    https://github.com/sans-dfir/sift-files/blob/master/scripts/parseusn.py
+    """
     while True:
         data = infile.read(65536).lstrip(b'\x00')
         if data:
@@ -116,12 +151,12 @@ def findFirstRecord(infile):
 
 
 def findNextRecord(infile, journalSize):
-    # There are runs of null bytes between USN records. I'm guessing
-    # this is done to ensure that journal records are cluster-aligned
-    # on disk.
-    # This function reads through these null bytes, returning an offset
-    # to the first byte of the the next USN record.
-
+    """
+    There are runs of null bytes between USN records. I'm guessing
+    this is done to ensure that journal records are cluster-aligned on disk.
+    This function reads through these null bytes, returning an offset
+    to the first byte of the the next USN record.
+    """
     while True:
         try:
             recordLength = struct.unpack_from('<I', infile.read(4))[0]
@@ -133,8 +168,10 @@ def findNextRecord(infile, journalSize):
                 sys.exit()
 
 
-def filetimeToHumanReadable( filetime):
-    # Borrowed from Willi Ballenthin's parse_usnjrnl.py
+def filetimeToHumanReadable(filetime):
+    """
+    Borrowed from Willi Ballenthin's parse_usnjrnl.py
+    """
     try:
         return str(datetime.utcfromtimestamp(float(filetime) * 1e-7 - 11644473600))
     except ValueError:
@@ -142,39 +179,77 @@ def filetimeToHumanReadable( filetime):
 
 
 def filetimeToEpoch(filetime):
-    return int(filetime / 10000000 - 11644473600)
+    """
+    Converts to Epoch Timestamp with milliseconds
+    """
+    return int(filetime / 10000 - 11644473600000)
 
 
 def convertFileReference(buf):
-    sequenceNumber = (buf >> 48) & 0xFFFF
-    entryNumber = buf & 0xFFFFFFFFFFFF
-    return sequenceNumber, entryNumber
+    """
+    Read, store, unpack, and return FileReference
+    """
+    b = memoryview(bytearray(struct.pack("<Q", buf)))
+    seq = struct.unpack_from("<h", b[6:8])[0]
+
+    b = memoryview(bytearray(b[0:6]))
+    byteString = ''
+
+    for i in b[::-1]:
+        byteString += format(i, 'x')
+    entry = int(byteString, 16)
+
+    return seq, entry
 
 
 def filenameHandler(infile, recordDict):
+    """
+    Read and return filename
+    """
     try:
         filename = struct.unpack_from('<{}s'.format(
-            recordDict[u'filenameLength']),
-            infile.read(recordDict[u'filenameLength']))[0]
+            recordDict['filenameLength']), infile.read(recordDict['filenameLength']))[0]
         return filename.decode('utf16')
-    except UnicodeDecodeError:
-        return u''
+    except struct.error:
+        return ''
 
 
 def convertAttributes(attributeType, data):
+    """
+    Identify attributes and return list
+    """
     attributeList = [attributeType[i] for i in attributeType if i & data]
-    return u' '.join(attributeList)
+    return ' '.join(attributeList)
 
 
 def main():
-    p = ArgumentParser()
-    p.add_argument('-b', '--body', help='Return USN records in comma-separated format', action='store_true')
-    p.add_argument('-c', '--csv', help='Return USN records in comma-separated format', action='store_true')
-    p.add_argument('-f', '--file', help='Parse the given USN journal file', required=True)
-    p.add_argument('-o', '--outfile', help='Parse the given USN journal file', required=True)
-    p.add_argument('-s', '--system', help='System name (use with -t)')
-    p.add_argument('-t', '--tln', help='TLN ou2tput (use with -s)', action='store_true')
-    p.add_argument('-v', '--verbose', help='Return all USN properties for each record (JSON)', action='store_true')
+    """
+    Main function for argument parsing and function execution
+    """
+    p = ArgumentParser(description=f'usnparser v{str(__version__)}')
+    p.add_argument('-f', '--file',
+                   metavar='FILE',
+                   help='Parse the given USN journal file',
+                   required=True)
+    p.add_argument('-o', '--outfile',
+                   metavar='FILE',
+                   help='Output records to given file',
+                   required=True)
+    p.add_argument('-b', '--body',
+                   help='Return USN records in body file format',
+                   action='store_true')
+    p.add_argument('-c', '--csv',
+                   help='Return USN records in comma-separated format',
+                   action='store_true')
+    p.add_argument('-t', '--tln',
+                   help='Return USN records in TLN format (use with -s to add hostname)',
+                   action='store_true')
+    p.add_argument('-s', '--system', metavar='NAME',
+                   help='System hostname (use with -t)')
+    p.add_argument('-V', '--verbose',
+                   help='Return all USN properties for each record (JSON only)',
+                   action='store_true')
+    p.add_argument('-v', '--version', action='version', version=p.description)
     args = p.parse_args()
 
     journalSize = os.path.getsize(args.file)
@@ -183,17 +258,17 @@ def main():
             i.seek(findFirstRecord(i))
 
             if args.csv:
-                o.write(u'timestamp,filename,fileattr,reason\n'.encode('utf-8', errors='backslashreplace'))
+                o.write(b'timestamp,filename,fileattr,reason\n')
                 while True:
                     nextRecord = findNextRecord(i, journalSize)
                     recordLength = struct.unpack_from('<I', i.read(4))[0]
                     recordData = struct.unpack_from('<2H4Q4I2H', i.read(56))
                     u = parseUsn(i, recordData)
-                    u = u'{0},{1},{2},{3}\n'.format(
-                        u[u'humanTimestamp'],
-                        u[u'filename'],
-                        u[u'fileAttributes'],
-                        u[u'reason'])
+                    u = '{0},{1},{2},{3}\n'.format(
+                        u['humanTimestamp'],
+                        u['filename'],
+                        u['fileAttributes'],
+                        u['reason'])
                     o.write(u.encode('utf8', errors='backslashreplace'))
                     i.seek(nextRecord)
 
@@ -203,33 +278,31 @@ def main():
                     recordLength = struct.unpack_from('<I', i.read(4))[0]
                     recordData = struct.unpack_from('<2H4Q4I2H', i.read(56))
                     u = parseUsn(i, recordData)
-                    u = u'0|{0} (USN: {1})|{2}-{3}|0|0|0|0|{4}|{4}|{4}|{4}\n'.format(
-                        u[u'filename'],
-                        u[u'reason'],
-                        u[u'mftEntryNumber'],
-                        u[u'mftSeqNumber'],
-                        u[u'epochTimestamp'],
-                        u[u'epochTimestamp'],
-                        u[u'epochTimestamp'],
-                        u[u'epochTimestamp'])
-
+                    u = '0|{0} (USN: {1})|{2}-{3}|0|0|0|0|{4}|{4}|{4}|{4}\n'.format(
+                        u['filename'],
+                        u['reason'],
+                        u['mftEntryNumber'],
+                        u['mftSeqNumber'],
+                        int(u['epochTimestamp'] / 1000),
+                        int(u['epochTimestamp'] / 1000),
+                        int(u['epochTimestamp'] / 1000),
+                        int(u['epochTimestamp'] / 1000))
                     o.write(u.encode('utf8', errors='backslashreplace'))
                     i.seek(nextRecord)
 
             elif args.tln:
                 if not args.system:
-                    args.system = u''
+                    args.system = ''
                 while True:
                     nextRecord = findNextRecord(i, journalSize)
                     recordLength = struct.unpack_from('<I', i.read(4))[0]
                     recordData = struct.unpack_from('<2H4Q4I2H', i.read(56))
                     u = parseUsn(i, recordData)
-                    u = u'{0}|USN|{1}||{2}:{3}\n'.format(
-                        u[u'epochTimestamp'],
+                    u = '{0}|USN|{1}||{2};{3}\n'.format(
+                        u['epochTimestamp'],
                         args.system,
-                        u[u'filename'],
-                        u[u'reason'])
-
+                        u['filename'],
+                        u['reason'])
                     o.write(u.encode('utf8', errors='backslashreplace'))
                     i.seek(nextRecord)
 
@@ -238,9 +311,10 @@ def main():
                     nextRecord = findNextRecord(i, journalSize)
                     recordLength = struct.unpack_from('<I', i.read(4))[0]
                     recordData = struct.unpack_from('<2H4Q4I2H', i.read(56))
-                    u = json.dumps(parseUsn(i, recordData), indent=4, ensure_ascii=False)
+                    u = json.dumps(parseUsn(i, recordData),
+                                   indent=4, ensure_ascii=False)
                     o.write(u.encode('utf8', errors='backslashreplace'))
-                    o.write(u'\n')
+                    o.write(b'\n')
                     i.seek(nextRecord)
 
             else:
@@ -249,17 +323,14 @@ def main():
                     recordLength = struct.unpack_from('<I', i.read(4))[0]
                     recordData = struct.unpack_from('<2H4Q4I2H', i.read(56))
                     u = parseUsn(i, recordData)
-                    u = u'{0} | {1} | {2} | {3}\n'.format(
-                        u[u'humanTimestamp'],
-                        u[u'filename'],
-                        u[u'fileAttributes'],
-                        u[u'reason'])
-
+                    u = '{0} | {1} | {2} | {3}\n'.format(
+                        u['humanTimestamp'],
+                        u['filename'],
+                        u['fileAttributes'],
+                        u['reason'])
                     o.write(u.encode('utf8', errors='backslashreplace'))
                     i.seek(nextRecord)
 
 
 if __name__ == '__main__':
     main()
-
-


### PR DESCRIPTION
Not sure if you're looking for any pull requests or assistance on this, but I was messing around with the USN Journal the other day and thought I could help bring this up to Python 3 spec.

Modified the epoch timestamp for milliseconds, added the filetime timestamp as the "timestamp" value (the hex version, as it exists on disk / in the file), removed the Python 2 __future__ and Unicode requirements (u''), and re-ordered the JSON output to show more relevant data first (personal preference, can be reverted by removing two lines).

Added a missing Attribute (INTEGRITY_CHANGE) and did some PEP8 cleanup.

Hope this helps!